### PR TITLE
Fix bugs in shared_lock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ endif()
 set(CMAKE_CXX_FLAGS ${NEWCXX_ENABLED_FLAG})
 message(STATUS "CMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}")
 
+set(CMAKE_EXE_LINKER_FLAGS  "-Wl,--no-as-needed ${CMAKE_EXE_LINKER_FLAGS}")
+
 enable_testing()
 
 ###################################

--- a/include/clue/shared_mutex.hpp
+++ b/include/clue/shared_mutex.hpp
@@ -332,9 +332,11 @@ public:
         swap(owns_, other.owns_);
     }
 
-    void release() {
+    mutex_type* release() {
+        auto ret = mut_;
         mut_ = nullptr;
         owns_ = false;
+        return ret;
     }
 
 public:

--- a/include/clue/shared_mutex.hpp
+++ b/include/clue/shared_mutex.hpp
@@ -356,24 +356,26 @@ public:
 
     void lock() {
         mut_->lock_shared();
+        owns_ = true;
     }
 
-    void try_lock() {
-        mut_->try_lock_shared();
+    bool try_lock() {
+        return owns_ = mut_->try_lock_shared();
     }
 
     template<class Rep, class Period>
     bool try_lock_for(const ::std::chrono::duration<Rep,Period>& duration) {
-        return mut_->try_lock_shared_for(duration);
+        return owns_ = mut_->try_lock_shared_for(duration);
     }
 
     template<class Clock, class Duration>
     bool try_lock_until(const ::std::chrono::time_point<Clock, Duration>& due_time) {
-        return mut_->try_lock_shared_until(due_time);
+        return owns_ = mut_->try_lock_shared_until(due_time);
     }
 
     void unlock() {
         mut_->unlock_shared();
+        owns_ = false;
     }
 
 }; // end class shared_lock

--- a/include/clue/shared_mutex.hpp
+++ b/include/clue/shared_mutex.hpp
@@ -362,17 +362,20 @@ public:
     }
 
     bool try_lock() {
-        return owns_ = mut_->try_lock_shared();
+        owns_ = mut_->try_lock_shared();
+        return owns_;
     }
 
     template<class Rep, class Period>
     bool try_lock_for(const ::std::chrono::duration<Rep,Period>& duration) {
-        return owns_ = mut_->try_lock_shared_for(duration);
+        owns_ = mut_->try_lock_shared_for(duration);
+        return owns_;
     }
 
     template<class Clock, class Duration>
     bool try_lock_until(const ::std::chrono::time_point<Clock, Duration>& due_time) {
-        return owns_ = mut_->try_lock_shared_until(due_time);
+        owns_ = mut_->try_lock_shared_until(due_time);
+        return owns_;
     }
 
     void unlock() {

--- a/tests/test_shared_mutex.cpp
+++ b/tests/test_shared_mutex.cpp
@@ -162,17 +162,14 @@ void test_shared_lock() {
 }
 
 void test_shared_unlock() {
-    std::puts("Testing shared unlocking ...");
     using mutex_t = shared_mutex;
     mutex_t mut;
     shared_lock<mutex_t> lk1(mut);
     lk1.unlock();
     assert(!lk1.owns_lock());
-    std::puts("  lk1 unlocked");
     lk1.~shared_lock();
     shared_lock<mutex_t> lk2(mut, std::defer_lock_t());
     assert(lk2.try_lock());
-    std::puts("  lk2 locked");
 }
 
 int main() {

--- a/tests/test_shared_mutex.cpp
+++ b/tests/test_shared_mutex.cpp
@@ -161,9 +161,24 @@ void test_shared_lock() {
     assert(correct);
 }
 
+void test_shared_unlock() {
+    std::puts("Testing shared unlocking ...");
+    using mutex_t = shared_mutex;
+    mutex_t mut;
+    shared_lock<mutex_t> lk1(mut);
+    lk1.unlock();
+    assert(!lk1.owns_lock());
+    std::puts("  lk1 unlocked");
+    lk1.~shared_lock();
+    shared_lock<mutex_t> lk2(mut, std::defer_lock_t());
+    assert(lk2.try_lock());
+    std::puts("  lk2 locked");
+}
+
 int main() {
     test_exclusive_lock();
     test_shared_lock();
+    test_shared_unlock();
     return 0;
 }
 


### PR DESCRIPTION
- update owns_ status after lock and unlock 
- shared_lock::release() returns the associated mutex (C++14)
