### PR TITLE
fix: thread blocked forever in concurrent_queue::wait_pop()

### DIFF
--- a/include/clue/concurrent_queue.hpp
+++ b/include/clue/concurrent_queue.hpp
@@ -41,28 +41,22 @@ public:
     }
 
     void push(const T& x) {
-        {
-            std::lock_guard<mutex_type> lk(mut_);
-            queue_.push(x);
-        }
-        if (size() == 1) cv1_.notify_one();
+        std::lock_guard<mutex_type> lk(mut_);
+        queue_.push(x);
+        if (size() == 1) cv1_.notify_all();
     }
 
     void push(T&& x) {
-        {
-            std::lock_guard<mutex_type> lk(mut_);
-            queue_.push(std::move(x));
-        }
-        if (size() == 1) cv1_.notify_one();
+        std::lock_guard<mutex_type> lk(mut_);
+        queue_.push(std::move(x));
+        if (size() == 1) cv1_.notify_all();
     }
 
     template<class... Args>
     void push(Args&&... args) {
-        {
-            std::lock_guard<mutex_type> lk(mut_);
-            queue_.emplace(std::forward<Args>(args)...);
-        }
-        if (size() == 1) cv1_.notify_one();
+        std::lock_guard<mutex_type> lk(mut_);
+        queue_.emplace(std::forward<Args>(args)...);
+        if (size() == 1) cv1_.notify_all();
     }
 
     // If it is non empty, pop and write the front element to dst,


### PR DESCRIPTION
this is a patch to fix #10 

1. use `notify_all` instead of `notify_one`.
2. keep `lk` during access to `size()`.
3. update test case to check the bug fixed